### PR TITLE
Rails 6.1のリリースノートへの文言を修正する

### DIFF
--- a/guides/source/ja/upgrading_ruby_on_rails.md
+++ b/guides/source/ja/upgrading_ruby_on_rails.md
@@ -410,7 +410,7 @@ NOTE: Rails 7.0で初めてスキーマをダンプすると、そのファイ�
 Rails 6.0からRails 6.1へのアップグレード
 -------------------------------------
 
-Rails 6.0の変更点について詳しくは[リリースノート](6_1_release_notes.html)を参照してください。
+Rails 6.1の変更点について詳しくは[リリースノート](6_1_release_notes.html)を参照してください。
 
 ### `Rails.application.config_for`の戻り値をStringキーでアクセスするサポートが終了した
 


### PR DESCRIPTION
なぜなら、Rails 6.0のリリースノートへのリンクのように文章上はなっているが、実際はRails 6.1のリリースノートへのリンクだから。